### PR TITLE
Run xgettext in addition to running the import function from Glotpress PHP code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN tar -xf wordpress.tar.gz && rm wordpress.tar.gz
 COPY lint.php lint.php
 COPY gplint /bin/gplint
 RUN chmod +x /bin/gplint
+
+RUN apt-get update -y && apt-get install -y gettext

--- a/gplint
+++ b/gplint
@@ -1,3 +1,5 @@
-#! /bin/bash
+#! /bin/bash -eu
+
+xgettext -o /dev/null "$@"
 
 php /lint.php "$@"


### PR DESCRIPTION
As discussed in Slack, and since it seems that sometimes the GlotPress import code does not complain even if the `.po` file is invalid, and because more tests are better than less…
This runs the `xgettext` command on the `.po` files to lint in order to add an additional way to validate the file format

---

Disclaimer: I haven't tested this change in practice, I'm just making a quick PR to suggest the addition before we forget.

⚠️ In particular, I haven't checked that `xgettext` (which is installed by default on macOS, and on many Linux distributions iinm) was installed on the Docker image our `Dockerfile` was based on. Would be worth double-checking before merging this.